### PR TITLE
FOLSPRINGB-4 Update module and deployment descriptor templates

### DIFF
--- a/descriptors/DeploymentDescriptor-template.json
+++ b/descriptors/DeploymentDescriptor-template.json
@@ -1,5 +1,5 @@
 {
-  "srvcId": "${artifactId}-${version}",
+  "srvcId": "@artifactId@-@version@",
   "nodeId": "localhost",
   "descriptor": {
     "exec": "java -Dport=%p -jar ../mod-spring-template/target/mod-spring-template.jar -Dhttp.port=%p embed_postgres=true"

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,5 +1,5 @@
 {
-  "id": "${artifactId}-${version}",
+  "id": "@artifactId@-@version@",
   "name": "The blueprint module that could be used as a template for folio spring based backend modules.",
   "provides": [
     {
@@ -25,7 +25,7 @@
   "permissionSets" : [],
   "requires": [],
   "launchDescriptor": {
-    "dockerImage": "${artifactId}:${version}",
+    "dockerImage": "@artifactId@:@version@",
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {


### PR DESCRIPTION
### Purpose
The replacement tokens for Spring-based modules are different from the normal form. Instead, they require tokens of the form: "@artifactId@-@version@". The maven builds then transforms the replacement tokens (for "artifactId" and "version") in those template descriptors, and the resultant final Descriptors are generated to `./target/ModuleDescriptor.json` etc.

All Spring-based modules must use this form in all `./descriptors/*Descriptor-template.json` files according to the documentation.
