### PR TITLE
FOLSPRINGB-46: Update dependencies (CVE-2022-21724)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-spring-template
 
-Copyright (C) 2020-2021 The Open Library Foundation
+Copyright (C) 2020-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.4.RELEASE</version>
+    <version>2.6.4</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -24,10 +24,10 @@
 
   <properties>
     <java.version>11</java.version>
-    <folio-spring-base.version>1.0.0</folio-spring-base.version>
-    <openapi-generator.version>4.3.1</openapi-generator.version>
-    <mapstruct.version>1.3.1.Final</mapstruct.version>
-    <json.version>20200518</json.version>
+    <folio-spring-base.version>4.0.0</folio-spring-base.version>
+    <openapi-generator.version>5.4.0</openapi-generator.version>
+    <mapstruct.version>1.4.2.Final</mapstruct.version>
+    <json.version>20211205</json.version>
   </properties>
 
   <dependencies>
@@ -85,13 +85,6 @@
           <artifactId>logback-classic</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>ru.yandex.qatools.embed</groupId>
-      <artifactId>postgresql-embedded</artifactId>
-      <version>2.10</version>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Update spring-boot-starter-parent from 2.3.4.RELEASE to 2.6.4. This bumps sub-dependency org.postgresql:postgresql from 42.2.16 to 42.3.3 fixing Remote Code Execution (RCE): https://nvd.nist.gov/vuln/detail/CVE-2022-21724

Update folio-spring-base from 1.0.0 to 4.0.0.
Update openapi-generator from 4.3.1 to 5.4.0.
Update mapstruct from 1.3.1.Final to 1.4.2.Final.
Update org.json:json from 20200518 to 20211205.

Remove postgresql-embedded. It has been unmaintained for a long time and can be replaced by testcontainers: https://github.com/yandex-qatools/postgresql-embedded#embedded-postgresql-server