### PR TITLE
FOLSPRINGB-59: Remove org.json:json, license is not open source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
     <folio-spring-base.version>4.0.0</folio-spring-base.version>
     <openapi-generator.version>5.4.0</openapi-generator.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
-    <json.version>20211205</json.version>
   </properties>
 
   <dependencies>
@@ -35,12 +34,6 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
       <version>${folio-spring-base.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>${json.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Remove org.json:json dependency because it has a license that is incompatible
with Apache 2.0 license and therefore must not be used for FOLIO.

For details see https://en.wikipedia.org/wiki/Douglas_Crockford#%22Good,_not_Evil%22

The README https://github.com/stleary/JSON-java explicitly suggests to
"choose a different package" when the license terms are not acceptable.